### PR TITLE
Console entry point without GUI

### DIFF
--- a/src/factorio_mod_downloader/__main__.py
+++ b/src/factorio_mod_downloader/__main__.py
@@ -105,7 +105,7 @@ class AppModDownloader(ModDownloader):
 
     def log_info(self, info):
         self.app.textbox.configure(state="normal")
-        self.app.textbox.insert("end", info)
+        self.app.textbox.insert("end", info + "\n")
         self.app.textbox.yview("end")
         self.app.textbox.configure(state="disabled")
 

--- a/src/factorio_mod_downloader/mod_downloader/__init__.py
+++ b/src/factorio_mod_downloader/mod_downloader/__init__.py
@@ -1,0 +1,3 @@
+from .mod_downloader import ModDownloader, WebsiteDownException
+
+__all__ = ["ModDownloader", "WebsiteDownException"]

--- a/src/factorio_mod_downloader/mod_downloader/__init__.py
+++ b/src/factorio_mod_downloader/mod_downloader/__init__.py
@@ -1,3 +1,13 @@
-from .mod_downloader import ModDownloader, WebsiteDownException
+from .mod_downloader import (
+    ModDownloader,
+    InvalidModURL,
+    InvalidDownloadFolder,
+    WebsiteDownException
+)
 
-__all__ = ["ModDownloader", "WebsiteDownException"]
+__all__ = [
+    "ModDownloader", 
+    "InvalidModURL",
+    "InvalidDownloadFolder",
+    "WebsiteDownException"
+]

--- a/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
+++ b/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
@@ -39,10 +39,10 @@ class ModDownloader(Thread):
                 raise Exception("Website down.")
 
             for mod_url in self.mod_urls:
-                self.log_info(f"Loading mod {mod_url}.\n")
+                self.log_info(f"Loading mod {mod_url}.")
                 self.download_mod_with_dependencies(BASE_MOD_URL + mod_url, self.output_path)
             
-            self.log_info("All mods downloaded successfully.\n")
+            self.log_info("All mods downloaded successfully.")
         except Exception as e:
             self.log_info(str(e))
             raise e
@@ -77,9 +77,9 @@ class ModDownloader(Thread):
     def _init_selenium(self):
         # Set up chrome options
         try:
-            self.log_info("Retrieving Chromium drivers.\n")
+            self.log_info("Retrieving Chromium drivers.")
             chromedriver_autoinstaller.install()
-            self.log_info("Chromium drivers successfully retrieved.\n")
+            self.log_info("Chromium drivers successfully retrieved.")
             chrome_options = Options()
 
             # Run in headless mode (without a GUI)
@@ -123,7 +123,7 @@ class ModDownloader(Thread):
                 percentage = progress / total_size
                 self.download_file_hook(percentage)
 
-        self.log_info(f"Downloaded: {file_path}.\n")
+        self.log_info(f"Downloaded: {file_path}.")
 
     def download_file_hook(self, percentage):
         """
@@ -188,9 +188,9 @@ class ModDownloader(Thread):
         latest_version = self.get_latest_version(soup)
 
         if mod_name == "" or latest_version == "":
-            self.log_info(f"Error getting nid from the {mod_url}. Please download it manually. Skipping!\n")
+            self.log_info(f"Error getting nid from the {mod_url}. Please download it manually. Skipping!")
 
-        self.log_info(f"Loaded mod {mod_name} with version {latest_version}.\n")
+        self.log_info(f"Loaded mod {mod_name} with version {latest_version}.")
 
         download_url = f"{BASE_DOWNLOAD_URL}/{mod_name}/{latest_version}.zip?anticache={self.generate_anticache()}"
         file_name = f"{mod_name}_{latest_version}.zip"
@@ -199,21 +199,21 @@ class ModDownloader(Thread):
         # Download the mod file
         os.makedirs(download_path, exist_ok=True)
         if file_name not in self.downloaded_mods:
-            self.log_info(f"Downloading {file_name}.\n")
+            self.log_info(f"Downloading {file_name}.")
             self.download_file(download_url, file_path, file_name)
             self.downloaded_mods.add(file_name)
         else:
-            self.log_info(f"Mod was already downloaded {file_name}. Skipping!\n")
+            self.log_info(f"Mod was already downloaded {file_name}. Skipping!")
 
         # Get required dependencies and recursively download them
-        self.log_info(f"Loading dependencies for {mod_name}.\n")
+        self.log_info(f"Loading dependencies for {mod_name}.")
         dependencies = self.get_required_dependencies(soup)
         if len(dependencies) == 0:
-            self.log_info(f"No dependency exists for {mod_name}.\n")
+            self.log_info(f"No dependency exists for {mod_name}.")
             return
 
         for dep_name, dep_url in dependencies:
-            self.log_info(f"Analayzing dependency {dep_name} of {mod_name}\n")
+            self.log_info(f"Analayzing dependency {dep_name} of {mod_name}")
             self.download_mod_with_dependencies(dep_url, download_path)
 
     def log_info(self, info):

--- a/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
+++ b/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
@@ -87,6 +87,15 @@ class ModDownloader(Thread):
             chrome_options.add_argument("--window-position=-2400,-2400")
             chrome_options.add_argument("--disable-gpu")
 
+            # This *should* remove the "Devtools listening on ws:..." logging
+            # messages printed to stdout, but due to a selenium/chromedriver bug
+            # it currently has no effect:
+            # https://github.com/SeleniumHQ/selenium/issues/16201
+            # A little ugly, but permissable.
+            chrome_options.add_experimental_option(
+                "excludeSwitches", ["enable-logging"]
+            )
+
             port = 9222
             while port:
                 if self.is_port_free(port):

--- a/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
+++ b/src/factorio_mod_downloader/mod_downloader/mod_downloader.py
@@ -23,12 +23,15 @@ class WebsiteDownException(Exception):
 
 
 class ModDownloader(Thread):
-    def __init__(self, mod_url, output_path, app):
+    def __init__(self, mod_urls, output_path, app):
         super().__init__()
         self.daemon = True
         self.output_path = output_path
-        self.mod = mod_url
-        self.mod_url = BASE_MOD_URL + mod_url
+        # self.mod_urls = [
+        #     BASE_MOD_URL + mod_url
+        #     for mod_url in mod_urls
+        # ]
+        self.mod_urls = mod_urls
         self.app = app
         self.downloaded_mods = set()
 
@@ -40,8 +43,9 @@ class ModDownloader(Thread):
             if not self.is_website_up(BASE_MOD_URL):
                 raise Exception("Website down.")
 
-            self.log_info(f"Loading mod {self.mod}.\n")
-            self.download_mod_with_dependencies(self.mod_url, self.output_path)
+            for mod_url in self.mod_urls:
+                self.log_info(f"Loading mod {mod_url}.\n")
+                self.download_mod_with_dependencies(BASE_MOD_URL + mod_url, self.output_path)
             self.log_info("All mods downloaded successfully.\n")
             self.app.progress_file.after(
                 0,


### PR DESCRIPTION
Implements #16.

# Features
## Command line arguments
```
> poetry run factorio-mod-downloader -h
usage: factorio-mod-downloader [-h] [--headless] [-s SOURCES [SOURCES ...]] [-f FILE] [-d DESTINATION] [-i]

Downloads Factorio mods and their dependencies.

options:
  -h, --help            show this help message and exit
  --headless            Download mods without launching the GUI.
  -s, --sources SOURCES [SOURCES ...]
                        A space-separated list of mod URLs to download.
  -f, --file FILE       The path to a text file containing a newline-separated list of mod URLs to download.
  -d, --destination DESTINATION
                        The destination folder mods should be downloaded to.
  -i, --ignore-overwrite
                        Automatically continues downloading even if the `destination` is not a completely empty folder. Only affects headless mode.
```
Feel free to rename any of these as you so wish.

## Multiple source URL
As hinted by `sources`, this PR now handles defining multiple URLs at the same time and downloads them all at once. This is represented in the GUI by making it a text box where each URL lives on a separate line. This can be improved appearance-wise, I basically just threw it together as a proof of concept.

<img width="742" height="692" alt="image" src="https://github.com/user-attachments/assets/77e75675-0011-4bff-85ff-8e8ac95cc27a" />

## `AppModDownloader` subclasses `ModDownloader`
All GUI specific stuff has been moved into the subclass `AppModDownloader`, while `ModDownloader` has been made fully independent beyond the input URLs and output folder. Checking the validity of mod URLs and folder paths has been moved to the constructor of `ModDownloader` to reduce code repetition.

This means that an external script should have a much easier time importing and using the `ModDownloader` class for their own purposes.

